### PR TITLE
Add clipboard hiding option

### DIFF
--- a/TypeClipboard/ActivePaster.cs
+++ b/TypeClipboard/ActivePaster.cs
@@ -35,6 +35,12 @@ namespace TypeClipboard
 
         public void UpdateTextbox(object? sender = null, EventArgs? e = null)
         {
+            if (Properties.Settings.Default.HideClipboardText)
+            {
+                textBox1.Text = "Clipboard Text Hidden";
+                return;
+            }
+
             if (Clipboard.ContainsText(TextDataFormat.UnicodeText))
             {
                 String clipboard = Clipboard.GetText(TextDataFormat.UnicodeText);

--- a/TypeClipboard/App.config
+++ b/TypeClipboard/App.config
@@ -16,6 +16,9 @@
             <setting name="CancelHotkey" serializeAs="String">
                 <value>F7</value>
             </setting>
+            <setting name="HideClipboardText" serializeAs="String">
+                <value>False</value>
+            </setting>
         </TypeClipboard.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TypeClipboard/MainPaster.Designer.cs
+++ b/TypeClipboard/MainPaster.Designer.cs
@@ -35,6 +35,7 @@
             textBox2 = new TextBox();
             button3 = new Button();
             chkEnter = new CheckBox();
+            chkHideClipboard = new CheckBox();
             toolTip1 = new ToolTip(components);
             pasteHKBtn = new Button();
             cancelHKBtn = new Button();
@@ -102,9 +103,20 @@
             toolTip1.SetToolTip(chkEnter, "If set, Type will type newline (\\n) as Enter, which is useful for large blobs of text.\r\n\r\nIf unset, Type will stop before the first newline, which is useful for passwords.");
             chkEnter.UseVisualStyleBackColor = true;
             chkEnter.CheckedChanged += CBEnter_CheckedChanged;
-            // 
+            //
+            // chkHideClipboard
+            //
+            chkHideClipboard.AutoSize = true;
+            chkHideClipboard.Location = new Point(12, 115);
+            chkHideClipboard.Name = "chkHideClipboard";
+            chkHideClipboard.Size = new Size(168, 19);
+            chkHideClipboard.TabIndex = 12;
+            chkHideClipboard.Text = "Hide Clipboard Text in Menu";
+            chkHideClipboard.UseVisualStyleBackColor = true;
+            chkHideClipboard.CheckedChanged += CHKHideClipboard_CheckedChanged;
+            //
             // toolTip1
-            // 
+            //
             toolTip1.ShowAlways = true;
             // 
             // pasteHKBtn
@@ -158,6 +170,7 @@
             Controls.Add(cancelHKBtn);
             Controls.Add(pasteHKBtn);
             Controls.Add(chkEnter);
+            Controls.Add(chkHideClipboard);
             Controls.Add(button3);
             Controls.Add(textBox2);
             Controls.Add(button2);
@@ -184,6 +197,7 @@
         private System.Windows.Forms.TextBox textBox2;
         private System.Windows.Forms.Button button3;
         private System.Windows.Forms.CheckBox chkEnter;
+        private System.Windows.Forms.CheckBox chkHideClipboard;
         private System.Windows.Forms.ToolTip toolTip1;
         private Button pasteHKBtn;
         private Button cancelHKBtn;

--- a/TypeClipboard/MainPaster.cs
+++ b/TypeClipboard/MainPaster.cs
@@ -120,6 +120,7 @@ namespace TypeClipboard
             cancelHKBtn.Text = "Cancel Hotkey: " + Properties.Settings.Default.CancelHotkey;
 
             chkEnter.Checked = Properties.Settings.Default.enableEnter;
+            chkHideClipboard.Checked = Properties.Settings.Default.HideClipboardText;
 
             ClipboardNotification.ClipboardUpdate += UpdateTextbox;
             UpdateTextbox();
@@ -141,6 +142,12 @@ namespace TypeClipboard
         {
             Properties.Settings.Default.enableEnter = chkEnter.Checked;
             Typer.AutoSubmit = chkEnter.Checked;
+            Properties.Settings.Default.Save();
+        }
+
+        private void CHKHideClipboard_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.HideClipboardText = chkHideClipboard.Checked;
             Properties.Settings.Default.Save();
         }
 

--- a/TypeClipboard/Properties/Settings.Designer.cs
+++ b/TypeClipboard/Properties/Settings.Designer.cs
@@ -58,5 +58,17 @@ namespace TypeClipboard.Properties {
                 this["CancelHotkey"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HideClipboardText {
+            get {
+                return ((bool)(this["HideClipboardText"]));
+            }
+            set {
+                this["HideClipboardText"] = value;
+            }
+        }
     }
 }

--- a/TypeClipboard/Properties/Settings.settings
+++ b/TypeClipboard/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="CancelHotkey" Type="System.String" Scope="User">
       <Value Profile="(Default)">F7</Value>
     </Setting>
+    <Setting Name="HideClipboardText" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- add `HideClipboardText` user setting
- expose checkbox in main window to toggle clipboard text masking
- mask clipboard contents in the insert menu when option is enabled

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877de59690c8322874c2fd969ff2ffc