### PR TITLE
Add clipboard text privacy option

### DIFF
--- a/TypeClipboard/ActivePaster.cs
+++ b/TypeClipboard/ActivePaster.cs
@@ -35,14 +35,28 @@ namespace TypeClipboard
 
         public void UpdateTextbox(object? sender = null, EventArgs? e = null)
         {
-            if (Clipboard.ContainsText(TextDataFormat.UnicodeText))
+            if (Properties.Settings.Default.HideClipboardText)
             {
-                String clipboard = Clipboard.GetText(TextDataFormat.UnicodeText);
-                textBox1.Text = clipboard;
+                if (Clipboard.ContainsText(TextDataFormat.UnicodeText))
+                {
+                    textBox1.Text = "Clipboard Text Hidden";
+                }
+                else
+                {
+                    textBox1.Text = "No text in clipboard";
+                }
             }
             else
             {
-                textBox1.Text = "No text in clipboard";
+                if (Clipboard.ContainsText(TextDataFormat.UnicodeText))
+                {
+                    string clipboard = Clipboard.GetText(TextDataFormat.UnicodeText);
+                    textBox1.Text = clipboard;
+                }
+                else
+                {
+                    textBox1.Text = "No text in clipboard";
+                }
             }
         }
 

--- a/TypeClipboard/MainPaster.Designer.cs
+++ b/TypeClipboard/MainPaster.Designer.cs
@@ -35,6 +35,7 @@
             textBox2 = new TextBox();
             button3 = new Button();
             chkEnter = new CheckBox();
+            chkHideClipboard = new CheckBox();
             toolTip1 = new ToolTip(components);
             pasteHKBtn = new Button();
             cancelHKBtn = new Button();
@@ -103,17 +104,28 @@
             chkEnter.UseVisualStyleBackColor = true;
             chkEnter.CheckedChanged += CBEnter_CheckedChanged;
             // 
+            // chkHideClipboard
+            // 
+            chkHideClipboard.AutoSize = true;
+            chkHideClipboard.Location = new Point(248, 112);
+            chkHideClipboard.Name = "chkHideClipboard";
+            chkHideClipboard.Size = new Size(146, 19);
+            chkHideClipboard.TabIndex = 8;
+            chkHideClipboard.Text = "Hide Clipboard Text";
+            chkHideClipboard.UseVisualStyleBackColor = true;
+            chkHideClipboard.CheckedChanged += CBHideClipboard_CheckedChanged;
+            //
             // toolTip1
-            // 
+            //
             toolTip1.ShowAlways = true;
-            // 
+            //
             // pasteHKBtn
             // 
             pasteHKBtn.AccessibleName = "";
             pasteHKBtn.Location = new Point(12, 58);
             pasteHKBtn.Name = "pasteHKBtn";
             pasteHKBtn.Size = new Size(155, 23);
-            pasteHKBtn.TabIndex = 8;
+            pasteHKBtn.TabIndex = 9;
             pasteHKBtn.Text = "Paste Hotkey: F8";
             pasteHKBtn.UseVisualStyleBackColor = true;
             pasteHKBtn.Click += Paste_HK_Btn_Click;
@@ -124,7 +136,7 @@
             cancelHKBtn.Location = new Point(178, 58);
             cancelHKBtn.Name = "cancelHKBtn";
             cancelHKBtn.Size = new Size(155, 23);
-            cancelHKBtn.TabIndex = 9;
+            cancelHKBtn.TabIndex = 10;
             cancelHKBtn.Text = "Cancel Hotkey: F7";
             cancelHKBtn.UseVisualStyleBackColor = true;
             cancelHKBtn.Click += Cancel_HK_Btn_Click;
@@ -136,7 +148,7 @@
             label1.Location = new Point(12, 9);
             label1.Name = "label1";
             label1.Size = new Size(87, 15);
-            label1.TabIndex = 10;
+            label1.TabIndex = 11;
             label1.Text = "Clipboard Text";
             // 
             // label2
@@ -146,7 +158,7 @@
             label2.Location = new Point(12, 129);
             label2.Name = "label2";
             label2.Size = new Size(72, 15);
-            label2.TabIndex = 11;
+            label2.TabIndex = 12;
             label2.Text = "Buffer Text";
             // 
             // MainPaster
@@ -158,6 +170,7 @@
             Controls.Add(cancelHKBtn);
             Controls.Add(pasteHKBtn);
             Controls.Add(chkEnter);
+            Controls.Add(chkHideClipboard);
             Controls.Add(button3);
             Controls.Add(textBox2);
             Controls.Add(button2);
@@ -184,6 +197,7 @@
         private System.Windows.Forms.TextBox textBox2;
         private System.Windows.Forms.Button button3;
         private System.Windows.Forms.CheckBox chkEnter;
+        private System.Windows.Forms.CheckBox chkHideClipboard;
         private System.Windows.Forms.ToolTip toolTip1;
         private Button pasteHKBtn;
         private Button cancelHKBtn;

--- a/TypeClipboard/MainPaster.cs
+++ b/TypeClipboard/MainPaster.cs
@@ -120,6 +120,7 @@ namespace TypeClipboard
             cancelHKBtn.Text = "Cancel Hotkey: " + Properties.Settings.Default.CancelHotkey;
 
             chkEnter.Checked = Properties.Settings.Default.enableEnter;
+            chkHideClipboard.Checked = Properties.Settings.Default.HideClipboardText;
 
             ClipboardNotification.ClipboardUpdate += UpdateTextbox;
             UpdateTextbox();
@@ -141,6 +142,12 @@ namespace TypeClipboard
         {
             Properties.Settings.Default.enableEnter = chkEnter.Checked;
             Typer.AutoSubmit = chkEnter.Checked;
+            Properties.Settings.Default.Save();
+        }
+
+        private void CBHideClipboard_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.HideClipboardText = chkHideClipboard.Checked;
             Properties.Settings.Default.Save();
         }
 

--- a/TypeClipboard/Properties/Settings.Designer.cs
+++ b/TypeClipboard/Properties/Settings.Designer.cs
@@ -58,5 +58,17 @@ namespace TypeClipboard.Properties {
                 this["CancelHotkey"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HideClipboardText {
+            get {
+                return ((bool)(this["HideClipboardText"]));
+            }
+            set {
+                this["HideClipboardText"] = value;
+            }
+        }
     }
 }

--- a/TypeClipboard/Properties/Settings.settings
+++ b/TypeClipboard/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="CancelHotkey" Type="System.String" Scope="User">
       <Value Profile="(Default)">F7</Value>
     </Setting>
+    <Setting Name="HideClipboardText" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
## Summary
- add user setting `HideClipboardText`
- support checkbox for hiding clipboard in MainPaster
- mask clipboard text in ActivePaster when setting is on

## Testing
- `dotnet build TypeClipboard.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877de59690c8322874c2fd969ff2ffc