### PR TITLE
Add clipboard text hiding option

### DIFF
--- a/TypeClipboard/ActivePaster.Designer.cs
+++ b/TypeClipboard/ActivePaster.Designer.cs
@@ -28,38 +28,50 @@
         /// </summary>
         private void InitializeComponent()
         {
-            textBox1 = new TextBox();
-            Paste = new Button();
+            textBox1 = new System.Windows.Forms.TextBox();
+            Paste = new System.Windows.Forms.Button();
+            chkHide = new System.Windows.Forms.CheckBox();
             SuspendLayout();
             // 
             // textBox1
             // 
-            textBox1.Location = new Point(12, 12);
+            textBox1.Location = new System.Drawing.Point(12, 12);
             textBox1.Name = "textBox1";
             textBox1.ReadOnly = true;
-            textBox1.Size = new Size(178, 23);
+            textBox1.Size = new System.Drawing.Size(178, 23);
             textBox1.TabIndex = 0;
             // 
             // Paste
             // 
-            Paste.Location = new Point(196, 12);
+            Paste.Location = new System.Drawing.Point(196, 12);
             Paste.Name = "Paste";
-            Paste.Size = new Size(75, 23);
+            Paste.Size = new System.Drawing.Size(75, 23);
             Paste.TabIndex = 1;
             Paste.Text = "Paste";
             Paste.UseVisualStyleBackColor = true;
             Paste.Click += Paste_Click;
             // 
+            // chkHide
+            // 
+            chkHide.AutoSize = true;
+            chkHide.Location = new System.Drawing.Point(12, 41);
+            chkHide.Name = "chkHide";
+            chkHide.Size = new System.Drawing.Size(130, 19);
+            chkHide.TabIndex = 12;
+            chkHide.Text = "Hide Clipboard Text";
+            chkHide.UseVisualStyleBackColor = true;
+            chkHide.CheckedChanged += CBHide_CheckedChanged;
+            // 
             // ActivePaster
             // 
-            AutoScaleMode = AutoScaleMode.None;
-            ClientSize = new Size(278, 45);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            ClientSize = new System.Drawing.Size(278, 68);
+            Controls.Add(chkHide);
             Controls.Add(Paste);
             Controls.Add(textBox1);
-            FormBorderStyle = FormBorderStyle.FixedDialog;
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             MaximizeBox = false;
-            Name = "ActivePaster";
-            StartPosition = FormStartPosition.Manual;
+            StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             Text = "Clip Typer";
             TopMost = true;
             Activated += Form1_Activated;
@@ -74,5 +86,6 @@
 
         private TextBox textBox1;
         private Button Paste;
+        private System.Windows.Forms.CheckBox chkHide;
     }
 }

--- a/TypeClipboard/ActivePaster.cs
+++ b/TypeClipboard/ActivePaster.cs
@@ -38,7 +38,14 @@ namespace TypeClipboard
             if (Clipboard.ContainsText(TextDataFormat.UnicodeText))
             {
                 String clipboard = Clipboard.GetText(TextDataFormat.UnicodeText);
-                textBox1.Text = clipboard;
+                if (Properties.Settings.Default.HideClipboardText)
+                {
+                    textBox1.Text = "Clipboard Text Hidden";
+                }
+                else
+                {
+                    textBox1.Text = clipboard;
+                }
             }
             else
             {

--- a/TypeClipboard/ActivePaster.cs
+++ b/TypeClipboard/ActivePaster.cs
@@ -16,7 +16,7 @@ namespace TypeClipboard
 
         private static ActivePaster? instance = null;
 
-        public static ActivePaster getInstance() => instance == null || instance.IsDisposed ? instance = new ActivePaster() : instance;
+        public static ActivePaster GetInstance() => instance == null || instance.IsDisposed ? instance = new ActivePaster() : instance;
 
         private ActivePaster()
         {
@@ -40,7 +40,7 @@ namespace TypeClipboard
                 String clipboard = Clipboard.GetText(TextDataFormat.UnicodeText);
                 if (Properties.Settings.Default.HideClipboardText)
                 {
-                    textBox1.Text = "Clipboard Text Hidden";
+                    textBox1.Text = "******************";
                 }
                 else
                 {
@@ -51,6 +51,21 @@ namespace TypeClipboard
             {
                 textBox1.Text = "No text in clipboard";
             }
+        }
+        
+        public void setHideCheck(bool check)
+        {
+            chkHide.Checked = check;
+        }
+        
+        public void CBHide_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.HideClipboardText = chkHide.Checked;
+            Properties.Settings.Default.Save();
+            MainPaster.GetInstance().setHideCheck(chkHide.Checked);
+            UpdateTextbox();
+            MainPaster.GetInstance().UpdateTextbox();
+            MainPaster.GetInstance().UpdateBufferVisibility();
         }
 
         private void Form1_Activated(object sender, EventArgs e)

--- a/TypeClipboard/App.config
+++ b/TypeClipboard/App.config
@@ -16,6 +16,9 @@
             <setting name="CancelHotkey" serializeAs="String">
                 <value>F7</value>
             </setting>
+            <setting name="HideClipboardText" serializeAs="String">
+                <value>False</value>
+            </setting>
         </TypeClipboard.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TypeClipboard/LLL/LowLevelMouseListener.cs
+++ b/TypeClipboard/LLL/LowLevelMouseListener.cs
@@ -163,7 +163,7 @@ namespace TypeClipboard.LLL
             {
                 MainPaster.GetInstance().Invoke((MethodInvoker)delegate
                 {
-                    _activePaster = ActivePaster.getInstance();
+                    _activePaster = ActivePaster.GetInstance();
                     _activePaster.Show();
                     _activePaster.BringToFront();
                     if (GetCursorPos(out POINT p))

--- a/TypeClipboard/MainPaster.Designer.cs
+++ b/TypeClipboard/MainPaster.Designer.cs
@@ -35,6 +35,7 @@
             textBox2 = new TextBox();
             button3 = new Button();
             chkEnter = new CheckBox();
+            chkHide = new CheckBox();
             toolTip1 = new ToolTip(components);
             pasteHKBtn = new Button();
             cancelHKBtn = new Button();
@@ -102,7 +103,19 @@
             toolTip1.SetToolTip(chkEnter, "If set, Type will type newline (\\n) as Enter, which is useful for large blobs of text.\r\n\r\nIf unset, Type will stop before the first newline, which is useful for passwords.");
             chkEnter.UseVisualStyleBackColor = true;
             chkEnter.CheckedChanged += CBEnter_CheckedChanged;
-            // 
+
+            // chkHide
+            //
+            chkHide.AutoSize = true;
+            chkHide.Location = new Point(248, 112);
+            chkHide.Name = "chkHide";
+            chkHide.Size = new Size(88, 19);
+            chkHide.TabIndex = 12;
+            chkHide.Text = "Hide text";
+            chkHide.UseVisualStyleBackColor = true;
+            chkHide.CheckedChanged += CBHide_CheckedChanged;
+
+            //
             // toolTip1
             // 
             toolTip1.ShowAlways = true;
@@ -157,6 +170,7 @@
             Controls.Add(label1);
             Controls.Add(cancelHKBtn);
             Controls.Add(pasteHKBtn);
+            Controls.Add(chkHide);
             Controls.Add(chkEnter);
             Controls.Add(button3);
             Controls.Add(textBox2);
@@ -184,6 +198,7 @@
         private System.Windows.Forms.TextBox textBox2;
         private System.Windows.Forms.Button button3;
         private System.Windows.Forms.CheckBox chkEnter;
+        private System.Windows.Forms.CheckBox chkHide;
         private System.Windows.Forms.ToolTip toolTip1;
         private Button pasteHKBtn;
         private Button cancelHKBtn;

--- a/TypeClipboard/MainPaster.Designer.cs
+++ b/TypeClipboard/MainPaster.Designer.cs
@@ -28,35 +28,34 @@
         /// </summary>
         private void InitializeComponent()
         {
-            components = new System.ComponentModel.Container();
-            textBox1 = new TextBox();
-            button1 = new Button();
-            button2 = new Button();
-            textBox2 = new TextBox();
-            button3 = new Button();
-            chkEnter = new CheckBox();
-            chkHide = new CheckBox();
-            toolTip1 = new ToolTip(components);
-            pasteHKBtn = new Button();
-            cancelHKBtn = new Button();
-            label1 = new Label();
-            label2 = new Label();
+            textBox1 = new System.Windows.Forms.TextBox();
+            button1 = new System.Windows.Forms.Button();
+            button2 = new System.Windows.Forms.Button();
+            textBox2 = new System.Windows.Forms.TextBox();
+            button3 = new System.Windows.Forms.Button();
+            chkEnter = new System.Windows.Forms.CheckBox();
+            chkHide = new System.Windows.Forms.CheckBox();
+            pasteHKBtn = new System.Windows.Forms.Button();
+            cancelHKBtn = new System.Windows.Forms.Button();
+            label1 = new System.Windows.Forms.Label();
+            label2 = new System.Windows.Forms.Label();
+            label3 = new System.Windows.Forms.Label();
             SuspendLayout();
             // 
             // textBox1
             // 
-            textBox1.Font = new Font("Consolas", 9F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            textBox1.Location = new Point(12, 30);
+            textBox1.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)0));
+            textBox1.Location = new System.Drawing.Point(12, 30);
             textBox1.Name = "textBox1";
             textBox1.ReadOnly = true;
-            textBox1.Size = new Size(230, 22);
+            textBox1.Size = new System.Drawing.Size(230, 22);
             textBox1.TabIndex = 0;
             // 
             // button1
             // 
-            button1.Location = new Point(248, 30);
+            button1.Location = new System.Drawing.Point(248, 30);
             button1.Name = "button1";
-            button1.Size = new Size(85, 22);
+            button1.Size = new System.Drawing.Size(85, 22);
             button1.TabIndex = 1;
             button1.Text = "Paste";
             button1.UseVisualStyleBackColor = true;
@@ -64,9 +63,9 @@
             // 
             // button2
             // 
-            button2.Location = new Point(248, 147);
+            button2.Location = new System.Drawing.Point(248, 110);
             button2.Name = "button2";
-            button2.Size = new Size(85, 22);
+            button2.Size = new System.Drawing.Size(85, 22);
             button2.TabIndex = 4;
             button2.Text = "Paste";
             button2.UseVisualStyleBackColor = true;
@@ -74,19 +73,19 @@
             // 
             // textBox2
             // 
-            textBox2.Font = new Font("Consolas", 9F, FontStyle.Regular, GraphicsUnit.Point, 0);
-            textBox2.Location = new Point(12, 147);
+            textBox2.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)0));
+            textBox2.Location = new System.Drawing.Point(12, 110);
             textBox2.Name = "textBox2";
             textBox2.ReadOnly = true;
-            textBox2.Size = new Size(230, 22);
+            textBox2.Size = new System.Drawing.Size(230, 22);
             textBox2.TabIndex = 5;
             // 
             // button3
             // 
             button3.AccessibleName = "c2bHKBtn";
-            button3.Location = new Point(12, 87);
+            button3.Location = new System.Drawing.Point(12, 58);
             button3.Name = "button3";
-            button3.Size = new Size(155, 22);
+            button3.Size = new System.Drawing.Size(155, 22);
             button3.TabIndex = 6;
             button3.Text = "Copy clipboard to buffer";
             button3.UseVisualStyleBackColor = true;
@@ -95,37 +94,31 @@
             // chkEnter
             // 
             chkEnter.AutoSize = true;
-            chkEnter.Location = new Point(248, 87);
+            chkEnter.Location = new System.Drawing.Point(12, 210);
             chkEnter.Name = "chkEnter";
-            chkEnter.Size = new Size(85, 19);
+            chkEnter.Size = new System.Drawing.Size(85, 19);
             chkEnter.TabIndex = 7;
             chkEnter.Text = "Auto. Enter";
-            toolTip1.SetToolTip(chkEnter, "If set, Type will type newline (\\n) as Enter, which is useful for large blobs of text.\r\n\r\nIf unset, Type will stop before the first newline, which is useful for passwords.");
             chkEnter.UseVisualStyleBackColor = true;
             chkEnter.CheckedChanged += CBEnter_CheckedChanged;
-
+            // 
             // chkHide
-            //
+            // 
             chkHide.AutoSize = true;
-            chkHide.Location = new Point(248, 112);
+            chkHide.Location = new System.Drawing.Point(103, 210);
             chkHide.Name = "chkHide";
-            chkHide.Size = new Size(88, 19);
+            chkHide.Size = new System.Drawing.Size(130, 19);
             chkHide.TabIndex = 12;
-            chkHide.Text = "Hide text";
+            chkHide.Text = "Hide Clipboard Text";
             chkHide.UseVisualStyleBackColor = true;
             chkHide.CheckedChanged += CBHide_CheckedChanged;
-
-            //
-            // toolTip1
-            // 
-            toolTip1.ShowAlways = true;
             // 
             // pasteHKBtn
             // 
             pasteHKBtn.AccessibleName = "";
-            pasteHKBtn.Location = new Point(12, 58);
+            pasteHKBtn.Location = new System.Drawing.Point(12, 176);
             pasteHKBtn.Name = "pasteHKBtn";
-            pasteHKBtn.Size = new Size(155, 23);
+            pasteHKBtn.Size = new System.Drawing.Size(155, 23);
             pasteHKBtn.TabIndex = 8;
             pasteHKBtn.Text = "Paste Hotkey: F8";
             pasteHKBtn.UseVisualStyleBackColor = true;
@@ -134,9 +127,9 @@
             // cancelHKBtn
             // 
             cancelHKBtn.AccessibleName = "";
-            cancelHKBtn.Location = new Point(178, 58);
+            cancelHKBtn.Location = new System.Drawing.Point(178, 176);
             cancelHKBtn.Name = "cancelHKBtn";
-            cancelHKBtn.Size = new Size(155, 23);
+            cancelHKBtn.Size = new System.Drawing.Size(155, 23);
             cancelHKBtn.TabIndex = 9;
             cancelHKBtn.Text = "Cancel Hotkey: F7";
             cancelHKBtn.UseVisualStyleBackColor = true;
@@ -145,27 +138,37 @@
             // label1
             // 
             label1.AutoSize = true;
-            label1.Font = new Font("Segoe UI", 9F, FontStyle.Bold, GraphicsUnit.Point, 0);
-            label1.Location = new Point(12, 9);
+            label1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)0));
+            label1.Location = new System.Drawing.Point(12, 9);
             label1.Name = "label1";
-            label1.Size = new Size(87, 15);
+            label1.Size = new System.Drawing.Size(87, 15);
             label1.TabIndex = 10;
             label1.Text = "Clipboard Text";
             // 
             // label2
             // 
             label2.AutoSize = true;
-            label2.Font = new Font("Segoe UI", 9F, FontStyle.Bold, GraphicsUnit.Point, 0);
-            label2.Location = new Point(12, 129);
+            label2.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)0));
+            label2.Location = new System.Drawing.Point(12, 92);
             label2.Name = "label2";
-            label2.Size = new Size(72, 15);
+            label2.Size = new System.Drawing.Size(72, 15);
             label2.TabIndex = 11;
             label2.Text = "Buffer Text";
             // 
+            // label3
+            // 
+            label3.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+            label3.Location = new System.Drawing.Point(12, 150);
+            label3.Name = "label3";
+            label3.Size = new System.Drawing.Size(100, 23);
+            label3.TabIndex = 13;
+            label3.Text = "Options";
+            // 
             // MainPaster
             // 
-            AutoScaleMode = AutoScaleMode.None;
-            ClientSize = new Size(345, 183);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
+            ClientSize = new System.Drawing.Size(345, 241);
+            Controls.Add(label3);
             Controls.Add(label2);
             Controls.Add(label1);
             Controls.Add(cancelHKBtn);
@@ -177,9 +180,8 @@
             Controls.Add(button2);
             Controls.Add(button1);
             Controls.Add(textBox1);
-            FormBorderStyle = FormBorderStyle.FixedDialog;
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             MaximizeBox = false;
-            Name = "MainPaster";
             Text = "Clip Typer";
             TopMost = true;
             Activated += Form1_Activated;
@@ -190,6 +192,8 @@
             PerformLayout();
         }
 
+        private System.Windows.Forms.Label label3;
+
         #endregion
 
         private System.Windows.Forms.TextBox textBox1;
@@ -199,11 +203,10 @@
         private System.Windows.Forms.Button button3;
         private System.Windows.Forms.CheckBox chkEnter;
         private System.Windows.Forms.CheckBox chkHide;
-        private System.Windows.Forms.ToolTip toolTip1;
-        private Button pasteHKBtn;
-        private Button cancelHKBtn;
+        private System.Windows.Forms.Button pasteHKBtn;
+        private System.Windows.Forms.Button cancelHKBtn;
         private Label label1;
-        private Label label2;
+        private System.Windows.Forms.Label label2;
     }
 }
 

--- a/TypeClipboard/MainPaster.cs
+++ b/TypeClipboard/MainPaster.cs
@@ -120,6 +120,7 @@ namespace TypeClipboard
             cancelHKBtn.Text = "Cancel Hotkey: " + Properties.Settings.Default.CancelHotkey;
 
             chkEnter.Checked = Properties.Settings.Default.enableEnter;
+            chkHide.Checked = Properties.Settings.Default.HideClipboardText;
 
             ClipboardNotification.ClipboardUpdate += UpdateTextbox;
             UpdateTextbox();
@@ -141,6 +142,12 @@ namespace TypeClipboard
         {
             Properties.Settings.Default.enableEnter = chkEnter.Checked;
             Typer.AutoSubmit = chkEnter.Checked;
+            Properties.Settings.Default.Save();
+        }
+
+        private void CBHide_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.HideClipboardText = chkHide.Checked;
             Properties.Settings.Default.Save();
         }
 

--- a/TypeClipboard/MainPaster.cs
+++ b/TypeClipboard/MainPaster.cs
@@ -17,6 +17,7 @@ namespace TypeClipboard
         private static MainPaster? instance;
         private HotkeyTypes? listening;
         private bool initiateTermination = false;
+        private String bufferText = String.Empty;
 
         public HotkeyTypes? Listening { get => listening; set => listening = value; }
 
@@ -75,7 +76,7 @@ namespace TypeClipboard
                     if (Clipboard.ContainsText(TextDataFormat.UnicodeText))
                     {
                         string clipboard = Clipboard.GetText(TextDataFormat.UnicodeText);
-                        textBox1.Text = clipboard;
+                        textBox1.Text = Properties.Settings.Default.HideClipboardText ? "******************" : clipboard;
                     }
                     else
                     {
@@ -134,8 +135,13 @@ namespace TypeClipboard
 
         private void ToBuffer_Click(object sender, EventArgs e)
         {
-            String clipboard = Clipboard.GetText(TextDataFormat.UnicodeText);
-            textBox2.Text = clipboard;
+            bufferText = Clipboard.GetText(TextDataFormat.UnicodeText);
+            UpdateBufferVisibility();
+        }
+
+        public void UpdateBufferVisibility()
+        {
+            textBox2.Text = Properties.Settings.Default.HideClipboardText ? "******************" : bufferText;
         }
 
         private void CBEnter_CheckedChanged(object sender, EventArgs e)
@@ -145,10 +151,19 @@ namespace TypeClipboard
             Properties.Settings.Default.Save();
         }
 
+        public void setHideCheck(bool check)
+        {
+            chkHide.Checked = check;
+        }
+
         private void CBHide_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.HideClipboardText = chkHide.Checked;
             Properties.Settings.Default.Save();
+            ActivePaster.GetInstance().setHideCheck(chkHide.Checked);
+            UpdateTextbox();
+            UpdateBufferVisibility();
+            ActivePaster.GetInstance().UpdateTextbox();
         }
 
         private void Paste_HK_Btn_Click(object sender, EventArgs e)

--- a/TypeClipboard/MainPaster.resx
+++ b/TypeClipboard/MainPaster.resx
@@ -1,64 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
-    Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
-    associated with the data types.
-
-    Example:
-
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-
-    There are any number of "resheader" rows that contain simple
-    name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
-    mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
-    extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
-    read any of the formats listed below.
-
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -112,12 +53,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
 </root>

--- a/TypeClipboard/Properties/Settings.Designer.cs
+++ b/TypeClipboard/Properties/Settings.Designer.cs
@@ -58,5 +58,17 @@ namespace TypeClipboard.Properties {
                 this["CancelHotkey"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HideClipboardText {
+            get {
+                return ((bool)(this["HideClipboardText"]));
+            }
+            set {
+                this["HideClipboardText"] = value;
+            }
+        }
     }
 }

--- a/TypeClipboard/Properties/Settings.settings
+++ b/TypeClipboard/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="CancelHotkey" Type="System.String" Scope="User">
       <Value Profile="(Default)">F7</Value>
     </Setting>
+    <Setting Name="HideClipboardText" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TypeClipboard/Typer.cs
+++ b/TypeClipboard/Typer.cs
@@ -17,7 +17,7 @@ namespace TypeClipboard
 
         public static async Task TypeText(string str)
         {
-            if (GetForegroundWindow() == ActivePaster.getInstance().Handle)
+            if (GetForegroundWindow() == ActivePaster.GetInstance().Handle)
                 return;
 
             IsTyping = true;


### PR DESCRIPTION
## Summary
- add `HideClipboardText` to app settings
- show new checkbox to control clipboard visibility
- update logic for ActivePaster popup to hide text when option enabled

## Testing
- `dotnet build TypeClipboard/TypeClipboard.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877de59690c8322874c2fd969ff2ffc